### PR TITLE
Number of threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.ppm
 
 mandelbrot_seq
+mandelbrot_seq_without_io
 mandelbrot_pth
 mandelbrot_omp
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+## Running ##
+
+```
+cd MAC5742-0219-EP1/src
+sudo ./run-measurements.sh <iterations> <n_threads>
+```
+
+Where `iterations` will set the upper bound for the image size (with the same semantics as the `ITERATIONS` variable at `run_measurements.sh`), while `n_threads` will set the number of threads for the paralelized versions.
+
+## Modifications from the original repository ##
+
+The pthreads version accepts the number of threads as an extra argument. With OpenMP, we set the number of threads via the `OMP_NUM_THREADS` environment variable, which the `run_measurements.sh` exports.

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ CC_OMP=-fopenmp
 CC_PTH=-pthread
 
 .PHONY: all
-all: $(OUTPUT)_omp $(OUTPUT)_pth $(OUTPUT)_seq
+all: $(OUTPUT)_omp $(OUTPUT)_pth $(OUTPUT)_seq $(OUTPUT)_seq_without_io
 
 $(OUTPUT)_omp: $(OUTPUT)_omp.c
 	$(CC) -o $(OUTPUT)_omp $(CC_OPT) $(CC_OMP) $(OUTPUT)_omp.c
@@ -20,6 +20,9 @@ $(OUTPUT)_pth: $(OUTPUT)_pth.c
 $(OUTPUT)_seq: $(OUTPUT)_seq.c
 	$(CC) -o $(OUTPUT)_seq $(CC_OPT) $(OUTPUT)_seq.c
 
+$(OUTPUT)_seq_without_io: $(OUTPUT)_seq_without_io.c
+	$(CC) -o $(OUTPUT)_seq_without_io $(CC_OPT) $(OUTPUT)_seq_without_io.c
+
 .PHONY: clean
 clean:
-	rm $(OUTPUT)_omp $(OUTPUT)_pth $(OUTPUT)_seq *$(IMAGE)
+	rm $(OUTPUT)_omp $(OUTPUT)_pth $(OUTPUT)_seq $(OUTPUT)_seq_without_io *$(IMAGE)

--- a/src/mandelbrot_pth.c
+++ b/src/mandelbrot_pth.c
@@ -158,12 +158,11 @@ void compute_mandelbrot(int i_x_start, int i_y_start, int i_x_end, int i_y_end){
                 iteration++){
                 z_y         = 2 * z_x * z_y + c_y;
                 z_x         = z_x_squared - z_y_squared + c_x;
-
                 z_x_squared = z_x * z_x;
                 z_y_squared = z_y * z_y;
             };
 
-            update_rgb_buffer(iteration, i_x, i_y);
+            /* update_rgb_buffer(iteration, i_x, i_y); */
         };
     };
 };
@@ -183,15 +182,24 @@ void threaded_compute_mandebrot() {
     struct compute_mandelbrot_args thread_data_array[n_threads];
 
     int t, rc;
-    int start_row, end_row, rows_per_thread;
+    int start_row, end_row, rows_per_thread, unattributed_rows;
 
-    rows_per_thread = image_size / (n_threads - 1);
+    rows_per_thread = image_size / n_threads;
+    unattributed_rows = image_size % n_threads;
 
     t = 0;
-    start_row = 0;
-    end_row = rows_per_thread;
 
-    while (start_row < i_y_max) {
+    for (start_row = 0; start_row < i_y_max; start_row = end_row) {
+
+        end_row = start_row + rows_per_thread;
+        if (unattributed_rows > 0) {
+            end_row += 1;
+            unattributed_rows -= 1;
+        }
+
+        if (end_row > i_y_max) {
+            end_row = i_y_max;
+        }
 
         thread_data_array[t].i_x_start = 0;
         thread_data_array[t].i_y_start = start_row;
@@ -202,12 +210,6 @@ void threaded_compute_mandebrot() {
         if (rc) {
             printf("Error creating thread: pthread_create() returned %d\n", rc);
             exit(-1);
-        }
-
-        start_row = end_row;
-        end_row = start_row + rows_per_thread;
-        if (end_row > i_y_max) {
-            end_row = i_y_max;
         }
 
         t++;
@@ -221,11 +223,11 @@ void threaded_compute_mandebrot() {
 int main(int argc, char *argv[]){
     init(argc, argv);
 
-    allocate_image_buffer();
+    /* allocate_image_buffer(); */
 
     threaded_compute_mandebrot();
 
-    write_to_file();
+    /* write_to_file(); */
 
     pthread_exit(NULL);
 

--- a/src/mandelbrot_pth.c
+++ b/src/mandelbrot_pth.c
@@ -3,7 +3,7 @@
 #include <math.h>
 #include <pthread.h>
 
-int NUM_THREADS = 10;
+int n_threads;
 
 double c_x_min;
 double c_x_max;
@@ -60,8 +60,8 @@ void allocate_image_buffer(){
 };
 
 void init(int argc, char *argv[]){
-    if(argc < 6){
-        printf("usage: ./mandelbrot_pth c_x_min c_x_max c_y_min c_y_max image_size\n");
+    if(argc < 7){
+        printf("usage: ./mandelbrot_pth c_x_min c_x_max c_y_min c_y_max image_size n_threads\n");
         printf("examples with image_size = 11500:\n");
         printf("    Full Picture:         ./mandelbrot_pth -2.5 1.5 -2.0 2.0 11500\n");
         printf("    Seahorse Valley:      ./mandelbrot_pth -0.8 -0.7 0.05 0.15 11500\n");
@@ -75,6 +75,7 @@ void init(int argc, char *argv[]){
         sscanf(argv[3], "%lf", &c_y_min);
         sscanf(argv[4], "%lf", &c_y_max);
         sscanf(argv[5], "%d", &image_size);
+        sscanf(argv[6], "%d", &n_threads);
 
         i_x_max           = image_size;
         i_y_max           = image_size;
@@ -171,23 +172,20 @@ void compute_mandelbrot(int i_x_start, int i_y_start, int i_x_end, int i_y_end){
 void *_compute_mandelbrot(void *thread_args) {
     struct compute_mandelbrot_args *args;
     args = (struct compute_mandelbrot_args *) thread_args;
-    printf("DEBUG: Thread running for rows %d to %d\n", args->i_y_start, args->i_y_end);
 
     compute_mandelbrot(args->i_x_start, args->i_y_start, args->i_x_end, args->i_y_end);
 
-    printf("DEBUG: Thread done for rows %d to %d\n", args->i_y_start, args->i_y_end);
     pthread_exit(NULL);
 }
 
 void threaded_compute_mandebrot() {
-    pthread_t threads[NUM_THREADS];
-    struct compute_mandelbrot_args thread_data_array[NUM_THREADS];
+    pthread_t threads[n_threads];
+    struct compute_mandelbrot_args thread_data_array[n_threads];
 
     int t, rc;
     int start_row, end_row, rows_per_thread;
 
-    rows_per_thread = image_size / (NUM_THREADS - 1);
-    printf("DEBUG: Rows per thread: %d\n", rows_per_thread);
+    rows_per_thread = image_size / (n_threads - 1);
 
     t = 0;
     start_row = 0;
@@ -199,8 +197,6 @@ void threaded_compute_mandebrot() {
         thread_data_array[t].i_y_start = start_row;
         thread_data_array[t].i_x_end   = i_x_max;
         thread_data_array[t].i_y_end   = end_row;
-
-        printf("DEBUG: Creating thread %d for rows %d to %d.\n", t, start_row, end_row);
 
         rc = pthread_create(&threads[t], NULL, _compute_mandelbrot, (void*) &thread_data_array[t]);
         if (rc) {
@@ -217,10 +213,7 @@ void threaded_compute_mandebrot() {
         t++;
     }
 
-    printf("DEBUG: All threads created, will start joining...\n");
-
-    for (t = 0; t < NUM_THREADS; t++) {
-        printf("DEBUG: Joining thread %d...\n", t);
+    for (t = 0; t < n_threads; t++) {
         pthread_join(threads[t], NULL);
     }
 }

--- a/src/mandelbrot_seq_without_io.c
+++ b/src/mandelbrot_seq_without_io.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include <omp.h>
 
 double c_x_min;
 double c_x_max;
@@ -52,12 +51,12 @@ void allocate_image_buffer(){
 
 void init(int argc, char *argv[]){
     if(argc < 6){
-        printf("usage: ./mandelbrot_omp c_x_min c_x_max c_y_min c_y_max image_size\n");
+        printf("usage: ./mandelbrot_seq c_x_min c_x_max c_y_min c_y_max image_size\n");
         printf("examples with image_size = 11500:\n");
-        printf("    Full Picture:         ./mandelbrot_omp -2.5 1.5 -2.0 2.0 11500\n");
-        printf("    Seahorse Valley:      ./mandelbrot_omp -0.8 -0.7 0.05 0.15 11500\n");
-        printf("    Elephant Valley:      ./mandelbrot_omp 0.175 0.375 -0.1 0.1 11500\n");
-        printf("    Triple Spiral Valley: ./mandelbrot_omp -0.188 -0.012 0.554 0.754 11500\n");
+        printf("    Full Picture:         ./mandelbrot_seq -2.5 1.5 -2.0 2.0 11500\n");
+        printf("    Seahorse Valley:      ./mandelbrot_seq -0.8 -0.7 0.05 0.15 11500\n");
+        printf("    Elephant Valley:      ./mandelbrot_seq 0.175 0.375 -0.1 0.1 11500\n");
+        printf("    Triple Spiral Valley: ./mandelbrot_seq -0.188 -0.012 0.554 0.754 11500\n");
         exit(0);
     }
     else{
@@ -132,31 +131,28 @@ void compute_mandelbrot(){
         if(fabs(c_y) < pixel_height / 2){
             c_y = 0.0;
         };
-        #pragma omp parallel private(i_x, c_x, z_x, z_y, z_x_squared, z_y_squared, iteration)
-        {
-            #pragma omp for
-            for(i_x = 0; i_x < i_x_max; i_x++){
-                c_x         = c_x_min + i_x * pixel_width;
 
-                z_x         = 0.0;
-                z_y         = 0.0;
+        for(i_x = 0; i_x < i_x_max; i_x++){
+            c_x         = c_x_min + i_x * pixel_width;
 
-                z_x_squared = 0.0;
-                z_y_squared = 0.0;
+            z_x         = 0.0;
+            z_y         = 0.0;
 
-                for(iteration = 0;
-                    iteration < iteration_max && \
-                    ((z_x_squared + z_y_squared) < escape_radius_squared);
-                    iteration++){
-                    z_y         = 2 * z_x * z_y + c_y;
-                    z_x         = z_x_squared - z_y_squared + c_x;
+            z_x_squared = 0.0;
+            z_y_squared = 0.0;
 
-                    z_x_squared = z_x * z_x;
-                    z_y_squared = z_y * z_y;
-                };
+            for(iteration = 0;
+                iteration < iteration_max && \
+                ((z_x_squared + z_y_squared) < escape_radius_squared);
+                iteration++){
+                z_y         = 2 * z_x * z_y + c_y;
+                z_x         = z_x_squared - z_y_squared + c_x;
 
-                /* update_rgb_buffer(iteration, i_x, i_y); */
+                z_x_squared = z_x * z_x;
+                z_y_squared = z_y * z_y;
             };
+
+            /* update_rgb_buffer(iteration, i_x, i_y); */
         };
     };
 };

--- a/src/run_measurements.sh
+++ b/src/run_measurements.sh
@@ -9,7 +9,7 @@ INITIAL_SIZE=16
 
 SIZE=$INITIAL_SIZE
 
-NAMES=('mandelbrot_seq' 'mandelbrot_pth' 'mandelbrot_omp')
+NAMES=('mandelbrot_seq' 'mandelbrot_seq_without_io' 'mandelbrot_pth' 'mandelbrot_omp')
 
 export OMP_NUM_THREADS=$N_THREADS
 

--- a/src/run_measurements.sh
+++ b/src/run_measurements.sh
@@ -2,13 +2,16 @@
 
 set -o xtrace
 
+N_THREADS=$2
 MEASUREMENTS=10
-ITERATIONS=10
+ITERATIONS=$1
 INITIAL_SIZE=16
 
 SIZE=$INITIAL_SIZE
 
 NAMES=('mandelbrot_seq' 'mandelbrot_pth' 'mandelbrot_omp')
+
+export OMP_NUM_THREADS=$N_THREADS
 
 make
 mkdir results
@@ -17,10 +20,10 @@ for NAME in ${NAMES[@]}; do
     mkdir results/$NAME
 
     for ((i=1; i<=$ITERATIONS; i++)); do
-            perf stat -r $MEASUREMENTS ./$NAME -2.5 1.5 -2.0 2.0 $SIZE >> full.log 2>&1
-            perf stat -r $MEASUREMENTS ./$NAME -0.8 -0.7 0.05 0.15 $SIZE >> seahorse.log 2>&1
-            perf stat -r $MEASUREMENTS ./$NAME 0.175 0.375 -0.1 0.1 $SIZE >> elephant.log 2>&1
-            perf stat -r $MEASUREMENTS ./$NAME -0.188 -0.012 0.554 0.754 $SIZE >> triple_spiral.log 2>&1
+            perf stat -r $MEASUREMENTS ./$NAME -2.5 1.5 -2.0 2.0 $SIZE $N_THREADS >> full.log 2>&1
+            perf stat -r $MEASUREMENTS ./$NAME -0.8 -0.7 0.05 0.15 $SIZE $N_THREADS >> seahorse.log 2>&1
+            perf stat -r $MEASUREMENTS ./$NAME 0.175 0.375 -0.1 0.1 $SIZE $N_THREADS >> elephant.log 2>&1
+            perf stat -r $MEASUREMENTS ./$NAME -0.188 -0.012 0.554 0.754 $SIZE $N_THREADS >> triple_spiral.log 2>&1
             SIZE=$(($SIZE * 2))
     done
 


### PR DESCRIPTION
- Adiciona versão sequencial sem IO e alocação de memória (`mandelbrot_seq_without_io`)
- Possibilita parametrização do número de threads das versões paralelas: 
  - Versão com pthreads aceita argumento extra `n_threads`
  - Versão openMP configurada à partir da variável de ambiente `OMP_NUM_THREADS`
- Remove IO das versões paralelas
- Adiciona parâmetros no script `run_measurements.sh`. Veja o novo readme.
---
Modificação do algoritmo de divisão de trabalho na versão com pthreads:
- Na versão anterior, calculávamos `rows_per_thread = rows / (n_threads - 1)`, e a última thread ficava com o resto. O que é totalmente incorreto quando o resto é 0.
- Agora calculamos `rows_per_thread = rows / n_threads` e adicionamos uma linha a mais no pedaço das `rows % n_threads` primeiras threads.